### PR TITLE
fix(allowed-access component): set loading state to true  on initial …

### DIFF
--- a/src/components/AllowedAccess.tsx
+++ b/src/components/AllowedAccess.tsx
@@ -25,7 +25,7 @@ const AllowedAccess = ({
   children
 }: PropsWithChildren<HasAccessProps>) => {
   const [allowedAccess, setAllowedAccess] = useState(false)
-  const [checking, setChecking] = useState(false)
+  const [checking, setChecking] = useState(true)
 
   useEffect(() => {
     const storedUser = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY_USER));


### PR DESCRIPTION
…load of  the component


## Description

When a user passes a component to be rendered as renderAuthFailed Props, this component is triggered a couple of seconds before the role and permission validation kicks in

Code sample

```ts
<AllowedAccess
      roles={[MODULE.DASHBOARD?.toLowerCase()]}
      renderAuthFailed={<p>Not Allowed to see this!</p>}
      isLoading={
        <Stack justifyContent="center" alignItems="center" height="50dvh">
          <CircularProgress color="primary" />
        </Stack>
      }
    >
    <SomeComponent />
       </AllowedAccess>
```

## Related Issues

[renderAuthFailed when present displays before permission and roles validation is checked ](https://github.com/arunkumarbrahmaniya/permission-react-role/issues/1)

## Type of Change


- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please specify)

## Checklist


- [x] I have tested my changes thoroughly.
- [x] My changes do not introduce new linting errors.

